### PR TITLE
Fix fixed charges dates not loading when editing a disbursement

### DIFF
--- a/dexter/forms.py
+++ b/dexter/forms.py
@@ -53,8 +53,8 @@ class CargoFijoForm(forms.ModelForm):
         widgets = {
             'codigo': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'Ej: CF001'}),
             'nombre_cargo_fijo': forms.TextInput(attrs={'class': 'form-control'}),
-            'fecha_efectiva': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
-            'fecha_revision': forms.DateInput(attrs={'class': 'form-control', 'type': 'date'}),
+            'fecha_efectiva': forms.DateInput(format='%Y-%m-%d', attrs={'class': 'form-control', 'type': 'date'}),
+            'fecha_revision': forms.DateInput(format='%Y-%m-%d', attrs={'class': 'form-control', 'type': 'date'}),
             'periodicidad': forms.TextInput(attrs={'class': 'form-control', 'placeholder': 'MENSUAL/ANUAL'}),
             'valor': forms.NumberInput(attrs={'class': 'form-control', 'step': '0.01'}),
         }


### PR DESCRIPTION
The DateInput widgets for fecha_efectiva and fecha_revision in
CargoFijoForm were missing the format='%Y-%m-%d' parameter. HTML5
date inputs require YYYY-MM-DD format, but Django renders dates in
its default locale format, causing existing dates to appear empty
on the edit form.

https://claude.ai/code/session_0197L9j32DLDp2DgANU2aYtV